### PR TITLE
Refactor paramless hashes (Breaking change)

### DIFF
--- a/src/Commands/ParamLessHasher.php
+++ b/src/Commands/ParamLessHasher.php
@@ -28,7 +28,7 @@ class ParamLessHasher
                 $wpdb->prepare(
                     "UPDATE wp_bonnier_redirects SET `paramless_from_hash` = MD5(%s), `from` = %s, `from_hash` = MD5(%s) WHERE `id` = %d",
                     [
-                        str_before($redirect->from, '?'),
+                        BonnierRedirect::trimAddSlash($redirect->from, false), // paramless
                         $trimmedFrom = BonnierRedirect::trimAddSlash($redirect->from),
                         $trimmedFrom,
                         $redirect->id
@@ -38,7 +38,7 @@ class ParamLessHasher
 
             if ($updatedRedirect) {
                 WP_CLI::success(sprintf("Fixed redirect %d from: %s",
-                        $redirect->id, $this->fix_encoding($redirect->from))
+                        $redirect->id, $redirect->from)
                 );
             }
         });

--- a/src/Commands/ParamLessHasher.php
+++ b/src/Commands/ParamLessHasher.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace Bonnier\WP\Redirect\Commands;
+
+use Bonnier\WP\Redirect\Http\BonnierRedirect;
+use WP_CLI;
+
+class ParamLessHasher
+{
+    const CMD_NAMESPACE = 'bonnier redirect fix';
+
+    public static function register() {
+        WP_CLI::add_command(static::CMD_NAMESPACE, __CLASS__);
+    }
+
+    /**
+     * wp bonnier redirect paramless_hash_add
+     */
+    public function paramless_hash_add()
+    {
+        global $wpdb;
+        $redirects = collect($wpdb->get_results(
+            "SELECT `id`, `from` FROM wp_bonnier_redirects"
+        ));
+        $redirects->each(function ($redirect) use ($wpdb) {
+            $updatedRedirect = $wpdb->query(
+                $wpdb->prepare(
+                    "UPDATE wp_bonnier_redirects SET `paramless_from_hash` = MD5(%s), `from` = %s, `from_hash` = MD5(%s) WHERE `id` = %d",
+                    [
+                        str_before($redirect->from, '?'),
+                        $trimmedFrom = BonnierRedirect::trimAddSlash($redirect->from),
+                        $trimmedFrom,
+                        $redirect->id
+                    ]
+                )
+            );
+
+            if ($updatedRedirect) {
+                WP_CLI::success(sprintf("Fixed redirect %d from: %s",
+                        $redirect->id, $this->fix_encoding($redirect->from))
+                );
+            }
+        });
+
+        WP_CLI::success("Done fixing redirects");
+    }
+}

--- a/src/Db/Bootstrap.php
+++ b/src/Db/Bootstrap.php
@@ -10,10 +10,11 @@ class Bootstrap
         $charset_collate = $wpdb->get_charset_collate();
 
         $sql = "SET sql_notes = 1;
-            CREATE TABLE IF NOT EXISTS `$table_name` (
+            CREATE TABLE `$table_name` (
               `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
               `from` text CHARACTER SET utf8 NOT NULL,
               `from_hash` char(32) COLLATE utf8mb4_unicode_520_ci NOT NULL,
+              `paramless_from_hash` char(32) COLLATE utf8mb4_unicode_520_ci NOT NULL,
               `to` text CHARACTER SET utf8 NOT NULL,
               `to_hash` char(32) COLLATE utf8mb4_unicode_520_ci NOT NULL,
               `locale` varchar(2) CHARACTER SET utf8 NOT NULL,
@@ -23,7 +24,8 @@ class Bootstrap
               PRIMARY KEY (`id`),
               UNIQUE KEY `from_hash` (`from_hash`,`to_hash`,`locale`),
               KEY `from_hash_2` (`from_hash`,`to_hash`,`locale`),
-              KEY `from_hash_3` (`from_hash`)
+              KEY `from_hash_3` (`from_hash`),
+              KEY `paramless_from_hash` (`paramless_from_hash`)
             ) $charset_collate;
             SET sql_notes = 1;
             ";

--- a/src/Http/BonnierRedirect.php
+++ b/src/Http/BonnierRedirect.php
@@ -11,7 +11,8 @@ class BonnierRedirect
         add_action('template_redirect', function(){
             $requestURI = $_SERVER['REQUEST_URI'];
             // Ask for final redirects
-            $redirect = self::recursiveRedirectFinder(self::trimAddSlash($requestURI));
+            $redirect = self::recursiveRedirectFinder($requestURI);
+
             // If an redirect is found
             if($redirect && isset($redirect->to)) {
                 // Redirect to it
@@ -31,7 +32,12 @@ class BonnierRedirect
 
     private static function redirectTo($to, $case, $requestURI) {
         header('X-Bonnier-Redirect: '.$case);
-        wp_redirect($to . (parse_url($requestURI, PHP_URL_QUERY) ? '?' : '') . parse_url($requestURI, PHP_URL_QUERY), $redirect->code ?? 301);
+        $query = parse_url($requestURI, PHP_URL_QUERY);
+        wp_redirect(
+            static::fixEncoding($to) . ($query ? '?' : '') . $query, // Build redirect with request query params
+            $redirect->code ?? 301
+        );
+        die(); // Prevent further execution to avoid hitting wp rocket cache
     }
 
     public static function getErrorString($type, $id) {
@@ -82,7 +88,7 @@ class BonnierRedirect
                     $wpdb->prepare(
                         "SELECT count(1) as `count` 
                     FROM wp_bonnier_redirects
-                    WHERE `from` = %s AND `locale` = %s",
+                    WHERE `from_hash` = MD5(%s) AND `locale` = %s",
                         $new,
                         $locale
                     )
@@ -131,7 +137,7 @@ class BonnierRedirect
                     $wpdb->prepare(
                         "SELECT count(1) as `count` 
                     FROM wp_bonnier_redirects
-                    WHERE `from` = %s AND `locale` = %s",
+                    WHERE `from_hash` = MD5(%s) AND `locale` = %s",
                         $url,
                         $url,
                         $locale
@@ -162,10 +168,11 @@ class BonnierRedirect
             $wpdb->get_row(
                 $wpdb->prepare(
                     "INSERT INTO `wp_bonnier_redirects` 
-                    (`from`, `from_hash`, `to`, `to_hash`, `locale`, `type`, `wp_id`, `code`) 
+                    (`from`, `from_hash`, `paramless_hash`, `to`, `to_hash`, `locale`, `type`, `wp_id`, `code`) 
                     VALUES (%s, MD5(%s), %s, MD5(%s), %s, %s, %s, %d)",
                     $fromUrl = self::trimAddSlash($from),
                     $fromUrl,
+                    self::trimAddSlash($fromUrl, false),
                     $toUrl = self::trimAddSlash($to),
                     $toUrl,
                     $locale,
@@ -222,6 +229,7 @@ class BonnierRedirect
      * @return mixed
      */
     private static function recursiveRedirectFinder($from) {
+        $from = self::trimAddSlash($from); // always look for the url without query params
         $redirect = self::findRedirectFor($from);
         // If it is an actual redirect
         if($redirect && isset($redirect->to)) {
@@ -246,19 +254,31 @@ class BonnierRedirect
      * @return array|null|object|void['a' => $newTo, 'b' => $from]
      */
     private static function findRedirectFor($uri) {
+        $paramlessUri = str_before($uri, '?');
         global $wpdb;
         try {
-            $redirect = $wpdb->get_row(
+            $redirects = collect($wpdb->get_results( // All redirects that match the path without params
                 $wpdb->prepare(
-                    "SELECT * FROM `wp_bonnier_redirects` WHERE `from` = %s AND `locale` = %s",
-                    $uri,
+                    "SELECT * FROM `wp_bonnier_redirects` WHERE `paramless_from_hash` = MD5(%s) AND `locale` = %s",
+                    $paramlessUri,
                     function_exists('pll_current_language') ? pll_current_language() : ''
                 )
-            );
+            ));
+            if($redirects->isEmpty()) {
+                return null;
+            }
+            $preciseMatch = $redirects->first(function($redirect) use($uri){
+                return $redirect->from === $uri;
+            });
+            if($preciseMatch) { // Matches full url with query params
+                return $preciseMatch;
+            }
+            return $redirects->first(function($redirect) use($uri){ // Matches just url path without query params
+                return !str_contains($redirect->from, '?');
+            });
         } catch (\Exception $e) {
-            $redirect = null;
+            return null;
         }
-        return $redirect;
     }
 
     /**
@@ -274,9 +294,10 @@ class BonnierRedirect
             $wpdb->get_row(
                 $wpdb->prepare(
                     "UPDATE wp_bonnier_redirects
-                     SET `to` = %s
+                     SET `to` = %s, `to_hash` = MD5(%s)
                      WHERE `from` = %s;
                     ",
+                    $newTo,
                     $newTo,
                     $from
                 )

--- a/wp-bonnier-redirect.php
+++ b/wp-bonnier-redirect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Bonnier Redirect
- * Version: 1.2.7
+ * Version: 1.3.0
  * Plugin URI: https://github.com/BenjaminMedia/wp-bonnier-redirect
  * Description: This plugin creates redirects with support for Polylang
  * Author: Bonnier - Nicklas Kevin Frank

--- a/wp-bonnier-redirect.php
+++ b/wp-bonnier-redirect.php
@@ -12,6 +12,7 @@ namespace Bonnier\WP\Redirect;
 
 // Do not access this file directly
 use Bonnier\WP\Redirect\Commands\CsvImport;
+use Bonnier\WP\Redirect\Commands\ParamLessHasher;
 use Bonnier\WP\Redirect\Commands\RedirectFixer;
 use Bonnier\WP\Redirect\Db\Bootstrap;
 use Bonnier\WP\Redirect\Http\BonnierRedirect;
@@ -95,6 +96,7 @@ class Plugin
         if ( defined('WP_CLI') && WP_CLI ) {
             CsvImport::register();
             RedirectFixer::register();
+            ParamLessHasher::register();
         }
 
         BonnierRedirect::register();


### PR DESCRIPTION
## Changes

- Refactored plugin to uses hashes for lookup when finding redirect
- Fixed a bug where redirects with parameters would not work in some cases
- Added parameterless hash to plugin
- Added WP-CLI CMD to create Paramless hash

## Deploying
When deployed the plugin should enabled/disabled and the new command should be run straight after