### PR TITLE
Bugfix - Proper user capability for pages

### DIFF
--- a/src/Controllers/ToolController.php
+++ b/src/Controllers/ToolController.php
@@ -39,10 +39,17 @@ class ToolController extends BaseController
     public function handlePost()
     {
         if ($this->request->isMethod(Request::METHOD_POST)) {
-            if ($this->request->request->get('export')) {
-                $this->exportRedirects();
-            } elseif ($this->request->request->get('import')) {
-                $this->importRedirects();
+            if (current_user_can('manage_options')) {
+                if ($this->request->request->get('export')) {
+                    $this->exportRedirects();
+                } elseif ($this->request->request->get('import')) {
+                    $this->importRedirects();
+                }
+            } else {
+                wp_die('Unauthorized', 'Error', [
+                    'response' => 403,
+                    'back_link' => admin_url('admin.php'),
+                ]);
             }
         }
     }

--- a/src/WpBonnierRedirect.php
+++ b/src/WpBonnierRedirect.php
@@ -142,7 +142,7 @@ class WpBonnierRedirect
         add_menu_page(
             'Bonnier Redirects',
             'Bonnier Redirects',
-            'manage_options',
+            'manage_categories', // Editor role
             'bonnier-redirects',
             [$listController, 'displayRedirectsTable'],
             'dashicons-external'
@@ -151,7 +151,7 @@ class WpBonnierRedirect
             'bonnier-redirects',
             'All Redirects',
             'All Redirects',
-            'manage_options',
+            'manage_categories', // Editor role
             'bonnier-redirects',
             [$listController, 'displayRedirectsTable']
         );
@@ -159,7 +159,7 @@ class WpBonnierRedirect
             'bonnier-redirects',
             'Add New',
             'Add New',
-            'manage_options',
+            'manage_categories', // Editor role
             'add-redirect',
             [$crudController, 'displayAddRedirectPage']
         );
@@ -167,7 +167,7 @@ class WpBonnierRedirect
             'bonnier-redirects',
             'Tools',
             'Tools',
-            'manage_options',
+            'manage_options', // Admin role
             'redirect-tools',
             [$toolController, 'displayToolPage']
         );

--- a/wp-bonnier-redirect.php
+++ b/wp-bonnier-redirect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Bonnier Redirect
- * Version: 4.3.0
+ * Version: 4.3.1
  * Plugin URI: https://github.com/BenjaminMedia/wp-bonnier-redirect
  * Description: This plugin creates redirects with support for Polylang
  * Author: Bonnier Publications


### PR DESCRIPTION
Updating the menu pages, so that editors can view, add, update and delete redirects, but only admins can import and export redirects.