### PR TITLE
WILL-1148 - Bugfix for creating ÆØÅ redirects

### DIFF
--- a/src/Helpers/UrlHelper.php
+++ b/src/Helpers/UrlHelper.php
@@ -18,7 +18,7 @@ class UrlHelper
         $path = parse_url($decoded, PHP_URL_PATH);
         $beginsWithSlash = Str::start($path, '/');
         $endsWithoutSlash = rtrim($beginsWithSlash, '/');
-        return strtolower($endsWithoutSlash);
+        return mb_strtolower($endsWithoutSlash);
     }
 
     /**
@@ -40,7 +40,7 @@ class UrlHelper
             foreach ($queryParams as $key => $value) {
                 $params .= sprintf('%s=%s&', $key, $value);
             }
-            $params = substr($params, 0, -1);
+            $params = mb_substr($params, 0, -1);
             $path = sprintf('%s%s', $path, $params);
         }
 
@@ -48,7 +48,7 @@ class UrlHelper
             $path = rtrim(rtrim($path, '*'), '/');
         }
 
-        if (substr($path, 0, 1) === '?') {
+        if (mb_substr($path, 0, 1) === '?') {
             $path = Str::start($path, '/');
         }
 
@@ -66,15 +66,15 @@ class UrlHelper
             $url = 'http://' . $url;
         }
         $parsedUrl = parse_url(self::decode($url));
-        $scheme = isset($parsedUrl['scheme']) ? strtolower($parsedUrl['scheme']) . '://' : '';
-        $host = strtolower($parsedUrl['host'] ?? '');
+        $scheme = isset($parsedUrl['scheme']) ? mb_strtolower($parsedUrl['scheme']) . '://' : '';
+        $host = mb_strtolower($parsedUrl['host'] ?? '');
         $normalizedUrl = rtrim($scheme . $host . self::normalizePath($url, $disallowWildcard), '/');
         foreach (LocaleHelper::getLocalizedUrls() as $domain) {
             if (Str::startsWith($normalizedUrl, $domain)) {
                 return Str::after($normalizedUrl, $domain) ?: '/';
             }
         }
-        if (substr($normalizedUrl, 0, 1) === '?') {
+        if (mb_substr($normalizedUrl, 0, 1) === '?') {
             $normalizedUrl = Str::start($normalizedUrl, '/');
         }
         return $normalizedUrl ?: '/';

--- a/wp-bonnier-redirect.php
+++ b/wp-bonnier-redirect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Bonnier Redirect
- * Version: 4.5.0
+ * Version: 4.5.1
  * Plugin URI: https://github.com/BenjaminMedia/wp-bonnier-redirect
  * Description: This plugin creates redirects with support for Polylang
  * Author: Bonnier Publications


### PR DESCRIPTION
When handling strings that potentially contains scandinavian characters like ÆØÅ, we'll need to use the multi-byte safe methods, instead of the regular string methods, since it can have weird side-effects based on what the server is configured to.