### PR TITLE
IVD-570 - Feature: Upload CSV of 404 and generate redirects

### DIFF
--- a/assets/scripts/tools.js
+++ b/assets/scripts/tools.js
@@ -1,11 +1,15 @@
 (function () {
-  var fileInput = document.getElementById('import-file');
-  var submitBtn = document.getElementById('import-submit');
-  fileInput.addEventListener('change', function (event) {
-    if (event.target.value) {
-      submitBtn.removeAttribute('disabled');
-    } else {
-      submitBtn.setAttribute('disabled', 'disabled');
-    }
-  });
+  function attachedFile(inputField, submitButton) {
+    var fileInput = document.getElementById(inputField);
+    var submitBtn = document.getElementById(submitButton);
+    fileInput.addEventListener('change', function (event) {
+      if (event.target.value) {
+        submitBtn.removeAttribute('disabled');
+      } else {
+        submitBtn.setAttribute('disabled', 'disabled');
+      }
+    });
+  }
+  attachedFile('import-file', 'import-submit');
+  attachedFile('404-file', '404-submit')
 })();

--- a/src/Helpers/LocaleHelper.php
+++ b/src/Helpers/LocaleHelper.php
@@ -2,6 +2,8 @@
 
 namespace Bonnier\WP\Redirect\Helpers;
 
+use Illuminate\Support\Str;
+
 class LocaleHelper
 {
     /**
@@ -26,6 +28,21 @@ class LocaleHelper
             return pll_get_term_language($termID) ?: self::getDefaultLanguage();
         }
         return self::getDefaultLanguage();
+    }
+
+    public static function getUrlLocale(string $url): ?string
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!$host) {
+            return null;
+        }
+        foreach (self::getLocalizedUrls() as $locale => $localizedUrl) {
+            if (Str::contains($localizedUrl, $host)) {
+                return $locale;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Views/tools.php
+++ b/src/Views/tools.php
@@ -32,6 +32,7 @@ $exampleCSV = \Bonnier\WP\Redirect\WpBonnierRedirect::instance()->assetURI('file
             >Download Export File</button>
         </p>
     </form>
+    <hr />
     <h2>Importing redirects</h2>
     <form id="import-redirects" method="post" enctype="multipart/form-data">
         <p>You can import redirects by uploading a CSV.</p>
@@ -48,6 +49,35 @@ $exampleCSV = \Bonnier\WP\Redirect\WpBonnierRedirect::instance()->assetURI('file
                 name="import"
                 value="import"
                 disabled
+            >Upload</button>
+        </p>
+    </form>
+    <hr />
+    <h2>Redirect 404 URLs</h2>
+    <form id="redirect-404" method="post" enctype="multipart/form-data">
+        <p>You can upload a CSV of URLs ending in 404 and the plugin will try to create redirects.</p>
+        <p>
+            <strong>NOTE:</strong> The CSV has to only contain one column of FULL URLs.
+            <br />
+            This means, that the URL should contain the domain as well (ie. https://example.com/page/gives/404)
+        </p>
+        <h4>Redirect creation rules:</h4>
+        <ol>
+            <li>If an article exists on the last part of the slug, a redirect will be created for that.</li>
+            <li>If a category page exists as part of the URL, a redirect will be created for that.</li>
+            <li>If a tag page exists as part of the URL, a redirect will be created for that.</li>
+            <li>Fallback: If none of the above rules apply, a redirect to the frontpage will be created.</li>
+        </ol>
+        <p><strong>NOTE:</strong> All redirects will be created as permanent redirects (301)</p>
+        <input type="file" name="404-file" id="404-file" />
+        <p class="submit">
+            <button
+                    type="submit"
+                    id="404-submit"
+                    class="button button-primary"
+                    name="404"
+                    value="404"
+                    disabled
             >Upload</button>
         </p>
     </form>

--- a/tests/_data/404-existing.csv
+++ b/tests/_data/404-existing.csv
@@ -1,0 +1,1 @@
+http://wp.test/my-test-category/my-test-post

--- a/tests/_data/404-rules.csv
+++ b/tests/_data/404-rules.csv
@@ -1,0 +1,5 @@
+http://wp.test/my-test-category/deleted-category/my-test-post
+http://wp.test/my-test-category/deleted-post
+http://wp.test/deleted-category/deleted-post
+http://wp.test/deleted-category
+http://wp.test/my-test-post

--- a/tests/_data/404-valid.csv
+++ b/tests/_data/404-valid.csv
@@ -1,0 +1,3 @@
+http://wp.test/some/fake/path
+http://wp.test/some/other/path
+http://wp.test/and/final/path

--- a/tests/_data/import-no-header.csv
+++ b/tests/_data/import-no-header.csv
@@ -1,0 +1,2 @@
+/category/article,/category,da,301
+/category/specific/article,https://example.com,da,302

--- a/tests/_data/import-valid.csv
+++ b/tests/_data/import-valid.csv
@@ -1,0 +1,3 @@
+from,to,locale,code
+/category/article,/category,da,301
+/category/specific/article,https://example.com,da,302

--- a/tests/integration/Controllers/ControllerTestCase.php
+++ b/tests/integration/Controllers/ControllerTestCase.php
@@ -3,6 +3,7 @@
 namespace Bonnier\WP\Redirect\Tests\integration\Controllers;
 
 use Bonnier\WP\Redirect\Controllers\CrudController;
+use Bonnier\WP\Redirect\Controllers\ToolController;
 use Bonnier\WP\Redirect\Database\DB;
 use Bonnier\WP\Redirect\Models\Redirect;
 use Bonnier\WP\Redirect\Repositories\LogRepository;
@@ -36,6 +37,12 @@ class ControllerTestCase extends TestCase
         }
     }
 
+    public function tearDown()
+    {
+        wp_set_current_user(0);
+        parent::tearDown();
+    }
+
     protected function assertManualRedirect(
         Redirect $redirect,
         string $fromUrl,
@@ -51,9 +58,9 @@ class ControllerTestCase extends TestCase
         $this->assertSame(0, $redirect->getWpID());
     }
 
-    protected function createPostRequest(array $args = []): Request
+    protected function createPostRequest(array $args = [], $files = []): Request
     {
-        return Request::create('/wp-admin/admin.php?page=' . CrudController::PAGE, 'POST', $args);
+        return Request::create('/wp-admin/admin.php?page=' . CrudController::PAGE, 'POST', $args, [], $files);
     }
 
     protected function createGetRequest(array $args = []): Request
@@ -139,5 +146,18 @@ class ControllerTestCase extends TestCase
         $crudController = new CrudController($this->logRepository, $this->redirectRepository, $request);
         $crudController->handlePost();
         return $crudController;
+    }
+
+    protected function getToolController(Request $request)
+    {
+        $toolController = new ToolController($this->redirectRepository, $request);
+        $toolController->handlePost();
+        return $toolController;
+    }
+
+    protected function actAsAdmin()
+    {
+        $userID = $this->factory()->user->create(['role' => 'administrator']);
+        wp_set_current_user($userID);
     }
 }

--- a/tests/integration/Controllers/ToolController/ImportRedirectsTest.php
+++ b/tests/integration/Controllers/ToolController/ImportRedirectsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Bonnier\WP\Redirect\Tests\integration\Controllers\ToolController;
+
+use Bonnier\WP\Redirect\Tests\integration\Controllers\ControllerTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class ImportRedirectsTest extends ControllerTestCase
+{
+    public function testCanCreateRedirectFromUploadedCSV()
+    {
+        $file = new UploadedFile(
+            $this->getData('import-valid.csv'),
+            'import-file.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest([
+            'import' => 'import',
+        ], [
+            'import-file' => $file
+        ]);
+
+        $this->actAsAdmin();
+
+        $controller = $this->getToolController($request);
+        $this->assertNoticeIs($controller->getNotices(), 'success', 'Redirects saved!');
+        $redirects = $this->findAllRedirects();
+        $this->assertCount(2, $redirects);
+        $this->assertRedirect(0, $redirects[0], '/category/article', '/category', 'csv-import');
+        $this->assertRedirect(0, $redirects[1], '/category/specific/article', 'https://example.com', 'csv-import', 302);
+    }
+
+    public function testMustBeAdminToImportRedirects()
+    {
+        $file = new UploadedFile(
+            $this->getData('import-valid.csv'),
+            'import-file.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest([
+            'import' => 'import'
+        ], [
+            'import-file' => $file
+        ]);
+
+        try {
+            $this->getToolController($request);
+        } catch (\Exception $exception) {
+            $this->assertEquals('Unauthorized', $exception->getMessage());
+            return;
+        }
+
+        $this->fail('Failed dismissing request as unauthorized');
+    }
+
+    public function testCSVMustContainAValidHeader()
+    {
+        $file = new UploadedFile(
+            $this->getData('import-no-header.csv'),
+            'import-file.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest(['import' => 'import'], ['import-file' => $file]);
+
+        $this->actAsAdmin();
+
+        $controller = $this->getToolController($request);
+        $this->assertNoticeIs($controller->getNotices(), 'error', 'CSV seems to be formatted incorrectly.');
+    }
+
+    public function testUploadedFileMustBeACSVFile()
+    {
+        $file = new UploadedFile(
+            $this->getData('import-no-header.csv'),
+            'original-name.csv',
+            'text/plain',
+            null,
+            true
+        );
+        $request = $this->createPostRequest(['import' => 'import'], ['import-file' => $file]);
+
+        $this->actAsAdmin();
+
+        $controller = $this->getToolController($request);
+        $this->assertNoticeIs($controller->getNotices(), 'error', 'Unable to process uploaded file.');
+    }
+}

--- a/tests/integration/Controllers/ToolController/Redirect404Test.php
+++ b/tests/integration/Controllers/ToolController/Redirect404Test.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Bonnier\WP\Redirect\Tests\integration\Controllers\ToolController;
+
+use Bonnier\WP\Redirect\Tests\integration\Controllers\ControllerTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class Redirect404Test extends ControllerTestCase
+{
+    public function testCanCreateRedirectsFrom404CSV()
+    {
+        $file = new UploadedFile(
+            $this->getData('404-valid.csv'),
+            'fix-404.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest(['404' => '404'], ['404-file' => $file]);
+
+        $this->actAsAdmin();
+
+        $controller = $this->getToolController($request);
+        $this->assertNoticeIs($controller->getNotices(), 'success', 'Redirects saved!');
+
+        $redirects = $this->findAllRedirects();
+        $this->assertCount(3, $redirects);
+        $this->assertRedirect(0, $redirects[0], '/some/fake/path', '/', 'csv-404-redirect');
+        $this->assertRedirect(0, $redirects[1], '/some/other/path', '/', 'csv-404-redirect');
+        $this->assertRedirect(0, $redirects[2], '/and/final/path', '/', 'csv-404-redirect');
+    }
+
+    public function testMustBeAdminToUpload404CSV()
+    {
+        $file = new UploadedFile(
+            $this->getData('404-valid.csv'),
+            'fix-404.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest(['404' => '404'], ['404-file' => $file]);
+
+        try {
+            $this->getToolController($request);
+        } catch (\Exception $exception) {
+            $this->assertEquals('Unauthorized', $exception->getMessage());
+            return;
+        }
+
+        $this->fail('Failed dismissing request as unauthorized');
+    }
+
+    public function testCreatesRedirectsBasedOnRules()
+    {
+        $category = $this->factory()->category->create_and_get(['slug' => 'my-test-category']);
+        $post = $this->factory()->post->create_and_get([
+            'post_category' => [$category->term_id],
+            'post_name' => 'my-test-post'
+        ]);
+
+        $this->assertEquals('http://wp.test/my-test-category/my-test-post/', get_permalink($post));
+
+        $file = new UploadedFile(
+            $this->getData('404-rules.csv'),
+            'fix-404.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest(['404' => '404'], ['404-file' => $file]);
+
+        $this->actAsAdmin();
+
+        $controller = $this->getToolController($request);
+        $this->assertNoticeIs($controller->getNotices(), 'success', 'Redirects saved!');
+
+        $redirects = $this->findAllRedirects();
+        $this->assertCount(5, $redirects);
+        $this->assertRedirect(
+            0,
+            $redirects[0],
+            '/my-test-category/deleted-category/my-test-post',
+            '/my-test-category/my-test-post',
+            'csv-404-redirect'
+        );
+        $this->assertRedirect(
+            0,
+            $redirects[1],
+            '/my-test-category/deleted-post',
+            '/my-test-category',
+            'csv-404-redirect'
+        );
+        $this->assertRedirect(
+            0,
+            $redirects[2],
+            '/deleted-category/deleted-post',
+            '/',
+            'csv-404-redirect'
+        );
+        $this->assertRedirect(
+            0,
+            $redirects[3],
+            '/deleted-category',
+            '/',
+            'csv-404-redirect'
+        );
+        $this->assertRedirect(
+            0,
+            $redirects[4],
+            '/my-test-post',
+            '/my-test-category/my-test-post',
+            'csv-404-redirect'
+        );
+    }
+
+    public function testCannotCreateRedirectOnValidURL()
+    {
+        $category = $this->factory()->category->create_and_get(['slug' => 'my-test-category']);
+        $post = $this->factory()->post->create_and_get([
+            'post_category' => [$category->term_id],
+            'post_name' => 'my-test-post'
+        ]);
+
+        $this->assertEquals('http://wp.test/my-test-category/my-test-post/', get_permalink($post));
+
+        $file = new UploadedFile(
+            $this->getData('404-existing.csv'),
+            'fix-404.csv',
+            'text/csv',
+            null,
+            true
+        );
+        $request = $this->createPostRequest(['404' => '404'], ['404-file' => $file]);
+
+        $this->actAsAdmin();
+
+        $controller = $this->getToolController($request);
+        $this->assertNoticeIs($controller->getNotices(), 'success', 'Redirects saved!');
+
+        $redirects = $this->findAllRedirects();
+        $this->assertNull($redirects);
+    }
+}

--- a/tests/integration/TestCase.php
+++ b/tests/integration/TestCase.php
@@ -96,6 +96,11 @@ class TestCase extends WPTestCase
         $this->assertSame($expectedRedirect->getParamlessFromHash(), $actualRedirect->getParamlessFromHash());
     }
 
+    protected function getData(string $filename): string
+    {
+        return sprintf('%s/_data/%s', rtrim(dirname(__DIR__), '/'), ltrim($filename, '/'));
+    }
+
     private function trimUrl(string $url)
     {
         return rtrim(parse_url($url, PHP_URL_PATH), '/');

--- a/wp-bonnier-redirect.php
+++ b/wp-bonnier-redirect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Bonnier Redirect
- * Version: 4.5.0
+ * Version: 4.6.0
  * Plugin URI: https://github.com/BenjaminMedia/wp-bonnier-redirect
  * Description: This plugin creates redirects with support for Polylang
  * Author: Bonnier Publications


### PR DESCRIPTION
This feature will allow admins to upload a CSV of URLs that returns 404 and have them automatically redirect.
A redirect will be created from the following rules:
1. An article exists as part of the last slug
2. A category exists as part of the slug
3. A tag exists as part of the slug
4. Fallback redirect to the frontpage.

- Added tests for import and 404 redirect Tool Controller actions
- Refactored ToolController to split reused code into smaller methods
- Refactored ToolController to store output log file in the uploads folder instead of the plugins asset folder.