### PR TITLE
WILL-1423/FIX: Category update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor
 wordpress
 wp-content
+*_deleted_duplicates.csv
 .env
 assets/files/*
 !assets/files/import-example.csv

--- a/src/Database/Migrations/AlterRedirectLogTableAddIdTypeIndex.php
+++ b/src/Database/Migrations/AlterRedirectLogTableAddIdTypeIndex.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bonnier\WP\Redirect\Database\Migrations;
+
+use Illuminate\Support\Str;
+
+class AlterRedirectLogTableAddIdTypeIndex implements Migration
+{
+    /**
+     * Run the migration
+     */
+    public static function migrate()
+    {
+        if (self::verify()) {
+            return;
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . Migrate::LOG_TABLE;
+
+        $changeTypeToVarchar = "
+        ALTER TABLE `$table`
+        MODIFY `type` VARCHAR(30);
+        ";
+        $wpdb->query($changeTypeToVarchar);
+
+        $addIndex = "
+        CREATE INDEX `wp_id_and_type`
+        ON `$table` (`wp_id`,`type`(30));
+        ";
+        $wpdb->query($addIndex);
+    }
+
+    /**
+     * Verify that the migration was run successfully
+     *
+     * @return bool
+     */
+    public static function verify(): bool
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . Migrate::LOG_TABLE;
+        $result = $wpdb->get_row("SHOW CREATE TABLE $table", ARRAY_A);
+        return isset($result['Create Table']) && Str::contains($result['Create Table'], 'wp_id_and_type');
+    }
+}

--- a/src/Database/Migrations/Migrate.php
+++ b/src/Database/Migrations/Migrate.php
@@ -18,6 +18,7 @@ class Migrate
             AlterRedirectTableAddIgnoreQuery::class,
             CreateLogTable::class,
             AlterRedirectTableAddWildcardColumn::class,
+            AlterRedirectLogTableAddIdTypeIndex::class,
         ]);
 
         if ($dbVersion >= count($migrations)) {

--- a/src/Observers/Redirects/CategorySlugChangeObserver.php
+++ b/src/Observers/Redirects/CategorySlugChangeObserver.php
@@ -42,6 +42,11 @@ class CategorySlugChangeObserver extends AbstractObserver
 
         $slug = $latest->getSlug();
 
+        if ($logs->isNotEmpty() && $slug === $logs->last()->getSlug()) {
+            // No changes happened to Category Slug
+            return;
+        }
+
         // Check for slug changes
         $noSlugChanges = true;
 

--- a/src/Observers/Redirects/TagSlugChangeObserver.php
+++ b/src/Observers/Redirects/TagSlugChangeObserver.php
@@ -35,6 +35,11 @@ class TagSlugChangeObserver extends AbstractObserver
 
             $slug = $latest->getSlug();
 
+            if ($logs->isNotEmpty() && $slug === $logs->last()->getSlug()) {
+                // No changes happened to Tag Slug
+                return;
+            }
+
             $logs->each(function (Log $log) use ($tag, $slug) {
                 if ($log->getSlug() !== $slug) {
                     $redirect = new Redirect();

--- a/src/Repositories/RedirectRepository.php
+++ b/src/Repositories/RedirectRepository.php
@@ -37,6 +37,14 @@ class RedirectRepository extends BaseRepository
         }
     }
 
+    public function getRedirects(Query $query): ?Collection
+    {
+        if ($results = $this->results($query)) {
+            return $this->mapRedirects($results);
+        }
+        return null;
+    }
+
     /**
      * @param int $redirectID
      * @return Redirect|null
@@ -157,7 +165,6 @@ class RedirectRepository extends BaseRepository
 
         return null;
     }
-
     /**
      * @param string|null $searchQuery
      * @param string|null $orderBy

--- a/tests/integration/Observers/Post/StatusChangeTest.php
+++ b/tests/integration/Observers/Post/StatusChangeTest.php
@@ -166,7 +166,7 @@ class StatusChangeTest extends ObserverTestCase
             'from' => $lastRedirect->getFrom(),
             'to' => $lastRedirect->getTo(),
             'code' => $lastRedirect->getCode(),
-            'locale' => 'da',
+            'locale' => 'nb',
             'wp_id' => 100,
             'type' => 'post-draft'
         ]);

--- a/wp-bonnier-redirect.php
+++ b/wp-bonnier-redirect.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Bonnier Redirect
- * Version: 4.7.1
+ * Version: 4.7.2
  * Plugin URI: https://github.com/BenjaminMedia/wp-bonnier-redirect
  * Description: This plugin creates redirects with support for Polylang
  * Author: Bonnier Publications


### PR DESCRIPTION
- Fixes issue where the plugin triggered uncessary calls to observers when no slug change
- Adds `wp_type_and_id` index on log table perfomance
- Fixes potential issue with republishing drafts that contain identical slugs in other languages